### PR TITLE
readme: add visa sponsorship page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Have a look at these other pages for more useful information:
 - **[Our story](./pages/story.md)** ☀️
 - **[Our values](./pages/values.md)** 🚀
 - **[Our perks and benefits](./pages/benefits.md)** 💍
+- **[Visa sponsorship](./pages/visa-sponsorship.md)** 🛫
 - **[Our remote-first culture](./pages/remote-first.md)** 🌎
 - **[How we work](./pages/how-we-work.md)** 🎳
 - **[Our stack](./pages/stack.md)** 📚

--- a/pages/visa-sponsorship.md
+++ b/pages/visa-sponsorship.md
@@ -1,0 +1,13 @@
+# Visa sponsorship 🛫
+
+We are able to provide visa sponsorship in: 
+- the United Kingdom 🇬🇧
+- Netherlands 🇳🇱
+- Germany 🇩🇪
+- France 🇫🇷
+
+Our new sponsorship initiative provides an exciting opportunity to relocate anywhere in these countries and collaborate with top engineers to revolutionise the world of payment technology.
+
+Once relocated, you can join our remote friendly environment from the UK, Netherlands, Germany or France. You can pursue a great adventure in your dream location 🏙 and write some awesome code with us! Win-Win! 🥳
+
+So, if you are curious to hear exactly how loud the Big Ben bongs ⏰  or how bright the lights on the Champs-Élysées really are💡, this opportunity is for YOU! 👈


### PR DESCRIPTION
This patch adds a new page about visa sponsorship to the
candidate pack. This will help the talent team highlight the
sponsorship opportunity in the candidate pack
https://github.com/form3tech/tech-evangelist-team/issues/51