### PR TITLE
readme: add teams description

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Have a look at these other pages for more useful information:
 - **[Our remote-first culture](./pages/remote-first.md)** 🌎
 - **[How we work](./pages/how-we-work.md)** 🎳
 - **[Our stack](./pages/stack.md)** 📚
+- **[Our engineering teams](./pages/teams.md)** 💻
 - **[What we look for](./pages/what-we-look-for.md)** 🔎
 - **[FAQ](./pages/faq.md)** 🤨
 

--- a/pages/teams.md
+++ b/pages/teams.md
@@ -1,0 +1,47 @@
+# Our engineering teams 💻
+
+We are firm believers that our teams should have autonomy and ownership of their work, and of the entire platform too.\
+With great power, comes great responsibility! 💪 \
+Our teams are responsible for every aspect of the work they are delivering, including testing, deployment and infrastructure. This gives our engineers a wide variety of challenges and growth opportunities.\
+Our team structure is organised with end-to-end ownership in mind.
+
+## TL;DR
+Our teams work closely together to solve complex problems on our market leading, cloud native payment processing platform. \
+To use a simple train analogy, we can summarise the work our teams do as: 
+- The platform teams build the train tracks 🛤
+- The tooling teams provide us with the best tools for building tracks and trains 🛠
+- The core teams build the trains that run on the tracks 🚆
+- The markets teams extend the trains and tracks to serve customers in multiple locations 🌎
+- The InfoSec teams make sure the train and tracks remain secure, during the maintenance and building process 🔐
+
+## Platform 🛤
+Our platform teams build, run and maintain our cloud native systems. The teams play a crucial role ensuring the reliability and scalability of our entire platform. \
+Here are some of the exciting things they do: 
+- Deliver and maintain our highly resilient, highly available, secure platform
+- Work with Cockroach DB and Cilium to build our next generation platform running accross multiple public clouds
+- Build and run our FPS data centers as an extension of our cloud solutions using Kubernetes, Cilium and NATS
+
+## Tooling 🛠
+Internal tools are a priority here at Form3, as they help our engineers deliver software at speed. Our tooling teams build and maintain our extensive developer tooling ecosystem.\
+Here are some of the exciting things they do:
+- Build, deploy and maintain Form3's internal tooling to enable 
+- Provide secure and reliable internal tools using Go, Terraform and various open-source tools to enable all our engineers to deliver globally
+- Work together with other teams to identify, gather requirements and deliver tools that improve our development and delivery processes
+
+## Core 🚆
+Our core teams build, run and maintain functional capabilities and services enabling successful payment processing on our platform.\
+Here are some of the exciting things they do: 
+- Develop and maintain shared functionality on our secure, multitenant systems through a mix of Java and Go development
+- Actively improve our low latency, high throughput distributed payment processing architecture
+- Ensure the complete monitoring and alerting of all our services using Prometheus and Grafana
+
+## Markets 🌎
+Our markets teams build and run payment processing services in UK, Europe and internationally. We support a wide variety of payment processing schemes such as FPS, BACS, SEPA, SWIFT and more.\
+Here are some of the exciting things they do:
+- Deliver payment products to their markets using the Form3 platform 
+- Maintain and implement the integrations between our platform and external payment scheme providers using Java and Go
+- Work on client functionality, ensuring the stability of our services and APIs that our customers integrate with
+
+## InfoSec 🔒
+Form3 have an extensive team of defensive and offensive engineering teams that work together with our security officers.\
+Our security teams work closely together with all our other engineering teams to ensure that we maintain the highest standards of security on our platform.

--- a/pages/visa-sponsorship.md
+++ b/pages/visa-sponsorship.md
@@ -1,7 +1,7 @@
 # Visa sponsorship 🛫
 
 We are able to provide visa sponsorship in: 
-- the United Kingdom 🇬🇧
+- United Kingdom 🇬🇧
 - Netherlands 🇳🇱
 - Germany 🇩🇪
 - France 🇫🇷


### PR DESCRIPTION
This patch adds engineering teams descriptions to the candidate pack.
This section is not a complete explanation of our teams as the pack is
intended for our product and platform candidates.
https://github.com/form3tech/tech-evangelist-team/issues/50