### PR TITLE
feat: add dedicated coding task page to the candidate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ At Form3 you will have the opportunity to:
 An initial telephone call with a member of our Talent Team.
 
 **Take Home Exercise** 🏡 <br>
-Candidates are asked to complete a technical exercise in Go. If you'd like to take a look at this exercise before applying, [here is the link](https://github.com/form3tech-oss/interview-accountapi). Please do not attempt this exercise until you have spoken with a member of Form3's Talent Team.
+Candidates are asked to complete a take home technical exercise in Go. Read more about our approach to [the technical coding task](./pages/coding-task.md).
 
 **Video Interview** 🎥 <br>
 Technical interview with 3 members of the Engineering Team via video-link. For further information on our interview process, please see the [FAQs](./pages/faq.md).

--- a/pages/coding-task.md
+++ b/pages/coding-task.md
@@ -1,0 +1,8 @@
+## The technical coding task
+We have opted for a take home coding task over a live coding exercise to allow our candidates to deliver their best work on their own timeline. This means that there is no deadline to our technical task.
+
+There are two coding tasks, depending on the role you are being considered for: 
+- The [software engineer coding task](https://github.com/form3tech-oss/interview-accountapi) focuses on the API design and implementation of a sample application. 
+- The [platform engineer coding task](https://github.com/form3tech-oss/platform-interview) focuses on the infrastructure configuration of a sample application. 
+
+Please do not attempt this exercise until you have spoken with a member of Form3's Talent Team.


### PR DESCRIPTION
This patch adds a new page for the technical coding task, which has
now been extended to link both engineering coding tasks.
Closes https://github.com/form3tech/tech-evangelist-team/issues/57
