### PR TITLE
bugfix for issue 13

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -43,9 +43,7 @@ Yes. Each technical exercise is reviewed by two engineers and they will provide 
 Here's a few other links where you can learn even more about us: 
 
 - **[Website](https://www.form3.tech/about)**
-- **[Newsroom](https://form3.tech/press)**
+- **[Insights](https://www.form3.tech/why-form3/insights)**
 - **[Vimeo](https://vimeo.com/form3)**
-- **[Blog](https://form3.tech/blog)**
 - **[Podcast](https://tech-by-form3.simplecast.com/)**
-- **[Stack Overflow profile](https://stackoverflow.com/jobs/companies/form3-financial-cloud)**
 - **[Github profile](https://github.com/form3tech-oss)**


### PR DESCRIPTION
Removed: Press link, as it is broken
Renamed and changed link: Blog, as the link has changed and Blog is the only link in Insights
Removed: Stack Overflow profile, as the functionality is not provided by the Stack Overflow any longer (since April 2022) 